### PR TITLE
WIP Replace Requires by Wants for docker.service

### DIFF
--- a/templates/default.service.j2
+++ b/templates/default.service.j2
@@ -6,7 +6,7 @@
 {% block unit %}
 Description={{ unit.description|default(unit_name) }}
 {% block requires %}
-Requires=docker.service
+Wants=docker.service
 {% endblock %}
 {% block after %}
 After=docker.service


### PR DESCRIPTION
When docker daemon is failing, using Requires in services systemd units is in conflict with docker's `--live-restore` as systemd assume if docker is failing, the all other units must be failing too.

https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Wants=

```
Wants=

A weaker version of Requires=. Units listed in this option will be started if the configuring unit is. However, if the listed units fail to start or cannot be added to the transaction, this has no impact on the validity of the transaction as a whole. This is the recommended way to hook start-up of one unit to the start-up of another unit.

Note that dependencies of this type may also be configured outside of the unit configuration file by adding symlinks to a .wants/ directory accompanying the unit file. For details, see above.
```